### PR TITLE
Add option for hints to skip probing the same client

### DIFF
--- a/design/craft/inclusivecache/src/Configs.scala
+++ b/design/craft/inclusivecache/src/Configs.scala
@@ -34,6 +34,7 @@ case class InclusiveCacheParams(
   portFactor: Int, // numSubBanks = (widest TL port * portFactor) / writeBytes
   memCycles: Int,  // # of L2 clock cycles for a memory round-trip (50ns @ 800MHz)
   physicalFilter: Option[PhysicalFilterParams] = None,
+  hintsSkipProbe: Boolean = false, // do hints probe the same client
   // Interior/Exterior refer to placement either inside the Scheduler or outside it
   // Inner/Outer refer to buffers on the front (towards cores) or back (towards DDR) of the L2
   bufInnerInterior: InclusiveCachePortParameters = InclusiveCachePortParameters.fullC,
@@ -48,7 +49,8 @@ class WithInclusiveCache(
   nWays: Int = 8,
   capacityKB: Int = 512,
   outerLatencyCycles: Int = 40,
-  subBankingFactor: Int = 4
+  subBankingFactor: Int = 4,
+  hintsSkipProbe: Boolean = false
 ) extends Config((site, here, up) => {
   case InclusiveCacheKey => InclusiveCacheParams(
       sets = (capacityKB * 1024)/(site(CacheBlockBytes) * nWays * nBanks),
@@ -67,6 +69,7 @@ class WithInclusiveCache(
       portFactor,
       memCycles,
       physicalFilter,
+      hintsSkipProbe,
       bufInnerInterior,
       bufInnerExterior,
       bufOuterInterior,
@@ -78,7 +81,8 @@ class WithInclusiveCache(
         ways = ways,
         sets = sets,
         blockBytes = sbus.blockBytes,
-        beatBytes = sbus.beatBytes),
+        beatBytes = sbus.beatBytes,
+        hintsSkipProbe = hintsSkipProbe),
       InclusiveCacheMicroParameters(
         writeBytes = writeBytes,
         portFactor = portFactor,

--- a/design/craft/inclusivecache/src/MSHR.scala
+++ b/design/craft/inclusivecache/src/MSHR.scala
@@ -273,7 +273,7 @@ class MSHR(params: InclusiveCacheParameters) extends Module
   val honour_BtoT = meta.hit && (meta.clients & req_clientBit).orR
 
   // The client asking us to act is proof they don't have permissions.
-  val excluded_client = Mux(meta.hit && request.prio(0) && skipProbeN(request.opcode), req_clientBit, UInt(0))
+  val excluded_client = Mux(meta.hit && request.prio(0) && skipProbeN(request.opcode, params.cache.hintsSkipProbe), req_clientBit, UInt(0))
   io.schedule.bits.a.bits.tag     := request.tag
   io.schedule.bits.a.bits.set     := request.set
   io.schedule.bits.a.bits.param   := Mux(req_needT, Mux(meta.hit, BtoT, NtoT), NtoB)
@@ -503,7 +503,7 @@ class MSHR(params: InclusiveCacheParameters) extends Module
   val new_request = Mux(io.allocate.valid, allocate_as_full, request)
   val new_needT = needT(new_request.opcode, new_request.param)
   val new_clientBit = params.clientBit(new_request.source)
-  val new_skipProbe = Mux(skipProbeN(new_request.opcode), new_clientBit, UInt(0))
+  val new_skipProbe = Mux(skipProbeN(new_request.opcode, params.cache.hintsSkipProbe), new_clientBit, UInt(0))
 
   val prior = cacheState(final_meta_writeback, Bool(true))
   def bypass(from: CacheState, cover: Boolean)(implicit sourceInfo: SourceInfo) {

--- a/design/craft/inclusivecache/src/Parameters.scala
+++ b/design/craft/inclusivecache/src/Parameters.scala
@@ -31,7 +31,8 @@ case class CacheParameters(
   ways:        Int,
   sets:        Int,
   blockBytes:  Int,
-  beatBytes:   Int) // inner
+  beatBytes:   Int, // inner
+  hintsSkipProbe: Boolean)
 {
   require (ways > 0)
   require (sets > 0)
@@ -267,12 +268,12 @@ object MetaData
     ((opcode === TLMessages.AcquireBlock || opcode === TLMessages.AcquirePerm) && param =/= TLPermissions.NtoB)
   }
   // Does a request prove the client need not be probed?
-  def skipProbeN(opcode: UInt): Bool = {
+  def skipProbeN(opcode: UInt, hintsSkipProbe: Boolean): Bool = {
     // Acquire(toB) and Get => is N, so no probe
     // Acquire(*toT) => is N or B, but need T, so no probe
     // Hint => could be anything, so probe IS needed
     // Put* => is N or B, so probe IS needed
-    opcode === TLMessages.AcquireBlock || opcode === TLMessages.AcquirePerm || opcode === TLMessages.Get
+    opcode === TLMessages.AcquireBlock || opcode === TLMessages.AcquirePerm || opcode === TLMessages.Get || (opcode === TLMessages.Hint && hintsSkipProbe.B)
   }
   def isToN(param: UInt): Bool = {
     param === TLPermissions.TtoN || param === TLPermissions.BtoN || param === TLPermissions.NtoN


### PR DESCRIPTION
This avoids self-evictions from private caches due to hints.